### PR TITLE
prevent tokenizer splitting compound tokens into smaller tokens

### DIFF
--- a/src/core/Tokenizer.js
+++ b/src/core/Tokenizer.js
@@ -60,6 +60,9 @@ export default class Tokenizer {
   }
 
   createReservedWordRegex(reservedWords) {
+    reservedWords = reservedWords.sort((a, b) => {
+      return b.length - a.length || a.localeCompare(b);
+    });
     const reservedWordsPattern = reservedWords.join('|').replace(/ /gu, '\\s+');
     return new RegExp(`^(${reservedWordsPattern})\\b`, 'iu');
   }

--- a/test/behavesLikeSqlFormatter.js
+++ b/test/behavesLikeSqlFormatter.js
@@ -526,4 +526,23 @@ export default function behavesLikeSqlFormatter(language) {
       );
     `);
   });
+
+  it('does not split UNION ALL in half', () => {
+    const result = sqlFormatter.format(`
+      SELECT * FROM tbl1
+      UNION ALL
+      SELECT * FROM tbl2;
+    `);
+    expect(result).toBe(dedent/* sql */ `
+      SELECT
+        *
+      FROM
+        tbl1
+      UNION ALL
+      SELECT
+        *
+      FROM
+        tbl2;
+    `);
+  });
 }


### PR DESCRIPTION
When a comound token (e.g. "UNION ALL") and its component parts ("UNION", "ALL")
all appear in a language specification, the formatter chooses whichever option
appears first in the language specification, which can sometimes split a compound
token into separate tokens. This commit sorts the list to prefer longer tokens
first, thereby ensuring that compound tokens do not get split.