### PR TITLE
fix handling of floating point numbers

### DIFF
--- a/src/core/Tokenizer.js
+++ b/src/core/Tokenizer.js
@@ -19,7 +19,7 @@ export default class Tokenizer {
    */
   constructor(cfg) {
     this.WHITESPACE_REGEX = /^(\s+)/u;
-    this.NUMBER_REGEX = /^((-\s*)?[0-9]+(\.[0-9]+)?|0x[0-9a-fA-F]+|0b[01]+)\b/u;
+    this.NUMBER_REGEX = /^((-\s*)?[0-9]+(\.[0-9]+)?([eE]-?[0-9]+(\.[0-9]+)?)?|0x[0-9a-fA-F]+|0b[01]+)\b/u;
     this.OPERATOR_REGEX = /^(!=|<>|==|<=|>=|!<|!>|\|\||::|->>|->|~~\*|~~|!~~\*|!~~|~\*|!~\*|!~|:=|.)/u;
 
     this.BLOCK_COMMENT_REGEX = /^(\/\*[^]*?(?:\*\/|$))/u;

--- a/test/behavesLikeSqlFormatter.js
+++ b/test/behavesLikeSqlFormatter.js
@@ -526,4 +526,15 @@ export default function behavesLikeSqlFormatter(language) {
       );
     `);
   });
+
+  it('correctly handles floats as single tokens', () => {
+    const result = sqlFormatter.format('SELECT 1e-9 AS a, 1.5e-10 AS b, 3.5E12 AS c, 3.5e12 AS d;');
+    expect(result).toBe(dedent/* sql */ `
+      SELECT
+        1e-9 AS a,
+        1.5e-10 AS b,
+        3.5E12 AS c,
+        3.5e12 AS d;
+    `);
+  });
 }


### PR DESCRIPTION
Floating point numbers in exponent format are being treated
as separate tokens. This commit extends the number regex to
treat exponent format floating points as a single token.